### PR TITLE
solves issue of product info not appearing on update product page

### DIFF
--- a/frontend/components/UpdateProduct.js
+++ b/frontend/components/UpdateProduct.js
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client';
 import gql from 'graphql-tag';
+import { useEffect } from 'react';
 import Form from './styles/Form';
 import DisplayError from './ErrorMessage';
 import useForm from '../lib/useForm';
@@ -34,7 +35,7 @@ const UPDATE_PRODUCT_MUTATION = gql`
   }
 `;
 
-// destructuring variable 'id' from props.id that is being sent via
+// destructuring variable 'id' from props.id that is being sent
 // via props in update.js when it invokes this component
 export default function UpdateProduct({ id }) {
   // 1: We need to get the existing product
@@ -55,6 +56,15 @@ export default function UpdateProduct({ id }) {
   // using destructuring to 'inputs' & 'handleChange'
   // from the useForm custom hook
   const { inputs, handleChange, clearForm, resetForm } = useForm(data?.Product);
+
+  // solves issue of product data not appearing on initial page load for the
+  // update product page
+  useEffect(() => {
+    if (data?.Product) {
+      resetForm(data.Product);
+    }
+  }, [data]);
+
   if (loading) return <p>Loading... </p>;
   // 3: We need the form to handle the updates
   return (
@@ -99,7 +109,7 @@ export default function UpdateProduct({ id }) {
             id="name"
             name="name"
             placeholder="Name"
-            value={inputs.name}
+            value={inputs.name || ''}
             onChange={handleChange}
           />
         </label>
@@ -110,7 +120,7 @@ export default function UpdateProduct({ id }) {
             id="price"
             name="price"
             placeholder="Price"
-            value={inputs.price}
+            value={inputs.price || ''}
             onChange={handleChange}
           />
         </label>
@@ -120,7 +130,7 @@ export default function UpdateProduct({ id }) {
             id="description"
             name="description"
             placeholder="description"
-            value={inputs.description}
+            value={inputs.description || ''}
             onChange={handleChange}
           />
         </label>

--- a/frontend/pages/update.js
+++ b/frontend/pages/update.js
@@ -1,6 +1,6 @@
 import CreateProduct from '../components/UpdateProduct';
 
-// destructuring propos.query into variable 'query'
+// destructuring props.query into variable 'query'
 export default function UpdatePage({ query }) {
   console.log(query);
   return (


### PR DESCRIPTION
**Cause of problem:**
Product info not initially showing up because the useForm() hook fetches the product data, but initially, data is undefined until the query completes. Since useForm is being initialized with data?.Product, the initial inputs values are empty, and they’re not updated when data becomes available.

**Solution:**
Added useEffect() hook to update the form input fields when the data becomes available after initial page load.

**Additional changes:**
Added || '' to the value property for each input. 

- This solves the React error "A component is changing an uncontrolled input to be controlled."  
- This is due to the values initially being undefined which React treats as 'uncontrolled'. 
- After the values are added once uesEffect() runs the values are defined which React treats as controlled. 
- Adding || '' gives the value a fallback property of '' which can be used initially when it's undefined then being replaced with the product data
